### PR TITLE
リポジトリのURLの入力の汎用化と各プロジェクトのビルドの実行時間を出力するようにした

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"java.configuration.updateBuildConfiguration": "interactive"
+	"java.configuration.updateBuildConfiguration": "interactive",
+	"java.compile.nullAnalysis.mode": "automatic"
 }

--- a/app/src/main/java/org/goodppy/BuildChecker.java
+++ b/app/src/main/java/org/goodppy/BuildChecker.java
@@ -3,31 +3,40 @@ package org.goodppy;
 import java.io.File;
 import java.io.IOException;
 
-
 /**
  * ビルドが正しく行えるかをチェックするクラス
  */
 public class BuildChecker {
+	/**
+	 * コンストラクタ
+	 */
 	public BuildChecker() {
 		// コンストラクタ
 	}
 
 	/**
-	 * @param localPath
+	 * ビルドが行えるかをチェックする
+	 * 
+	 * @param localPath クローン先のディレクトリのパス
 	 */
-	public void BuildCheck(String localPath) {
+	public void buildCheck(String localPath) {
 		try {
 			System.out.println("Start the build...");
+			long start = System.currentTimeMillis();
 			ProcessBuilder builder = new ProcessBuilder();
-			builder.command("gradle", "build");
+			builder.command("gradle", "build"); // Gradleのビルドを行う
 			builder.directory(new File(localPath));
 			Process process = builder.start();
 			Integer exitCode = process.waitFor();
 			if (exitCode != 0) {
 				System.out.println("Build failed");
+				long end = System.currentTimeMillis();
+				System.out.println("Time taken to build : " + (end - start) + "ms");
 				return;
 			}
 			System.out.println("Build success");
+			long end = System.currentTimeMillis();
+			System.out.println("Time taken to build : " + (end - start) + "ms");
 		} catch (IOException | InterruptedException e) {
 			e.printStackTrace();
 		}

--- a/app/src/main/java/org/goodppy/Main.java
+++ b/app/src/main/java/org/goodppy/Main.java
@@ -1,20 +1,37 @@
 package org.goodppy;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
 /**
  * メインクラス
  */
 public class Main {
 	/**
-	 * @param args
+	 * メインメソッド
+	 * 
+	 * @param args コマンドライン引数
 	 */
 	public static void main(String[] args) {
-		String repositoryUrl = "https://github.com/tamadalab/MarryLab.git";
-		String localPath = "./repositories/MarryLab";
-		RepositoryController repositoryController = new RepositoryController(
-				repositoryUrl, localPath);
-		repositoryController.GitClone();
-		BuildChecker buildChecker = new BuildChecker();
-		buildChecker.BuildCheck(localPath);
+		String repositoriesList = "./src/main/resource/repositories.txt";
+		try (BufferedReader bufferedReader = new BufferedReader(new FileReader(repositoriesList))) {
+			String repositoryUrl;
+			while ((repositoryUrl = bufferedReader.readLine()) != null) {
+				System.out.println("----------------------------------------");
+				System.out.printf("Start the evaluation of %s\n", repositoryUrl);
+				RepositoryController repositoryController = new RepositoryController(repositoryUrl);
+				repositoryController.gitClone();
+				BuildChecker buildChecker = new BuildChecker();
+				buildChecker.buildCheck(repositoryController.getLocalPath());
+				System.out.printf("End the evaluation of %s\n", repositoryUrl);
+			}
+			System.out.println("----------------------------------------");
+			System.out.println("End the evaluation of all repositories");
+		} catch (IOException e) {
+			e.printStackTrace();
+
+		}
 
 		return;
 	}

--- a/app/src/main/java/org/goodppy/RepositoryController.java
+++ b/app/src/main/java/org/goodppy/RepositoryController.java
@@ -6,28 +6,87 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 
 /**
- * 評価するリポジトリに関する操作を行うクラス
+ * 評価するリポジトリについて操作を行うクラス
  */
 public class RepositoryController {
-	private String repositoryUrl;
 
+	/**
+	 * クローン先のディレクトリのパス
+	 */
 	private String localPath;
 
 	/**
-	 * @param repositoryUrl
-	 * @param localPath
+	 * リポジトリのオーナー名
 	 */
-	public RepositoryController(String repositoryUrl, String localPath) {
+	private String owner;
+
+	/**
+	 * リポジトリ名
+	 */
+	private String repositoryName;
+
+	/**
+	 * リポジトリのURL
+	 */
+	private String repositoryUrl;
+
+	/**
+	 * コンストラクタ
+	 */
+	public RepositoryController(String repositoryUrl) {
 		this.repositoryUrl = repositoryUrl;
-		this.localPath = localPath;
+		this.owner = makeUrlParts()[makeUrlParts().length - 2];
+		this.repositoryName = makeUrlParts()[makeUrlParts().length - 1].replace(".git", "");
+		this.localPath = "./repositories/" + getOwner() + "/" + getRepositoryName(); // ./repositories/owner/repositoryName
+
+		return;
 	}
 
-	public void GitClone() {
+	/**
+	 * クローン先のディレクトリのパスを取得する
+	 * 
+	 * @return クローン先のディレクトリのパス
+	 */
+	public String getLocalPath() {
+		return this.localPath;
+	}
+
+	/**
+	 * リポジトリのオーナー名を取得する
+	 * 
+	 * @return リポジトリのオーナー名
+	 */
+	public String getOwner() {
+		return this.owner;
+	}
+
+	/**
+	 * リポジトリ名を取得する
+	 * 
+	 * @return リポジトリ名
+	 */
+	public String getRepositoryName() {
+		return this.repositoryName;
+	}
+
+	/**
+	 * リポジトリのURLを取得する
+	 * 
+	 * @return リポジトリのURL
+	 */
+	public String getRepositoryUrl() {
+		return this.repositoryUrl;
+	}
+
+	/**
+	 * リポジトリをクローンする
+	 */
+	public void gitClone() {
 		try {
-			System.out.println("Repository is being cloned ...");
+			System.out.println("Repository is being cloned...");
 			Git.cloneRepository()
-					.setURI(repositoryUrl)
-					.setDirectory(new File(localPath))
+					.setURI(getRepositoryUrl())
+					.setDirectory(new File(getLocalPath()))
 					.call();
 			System.out.println("Repository has been cloned.");
 		} catch (GitAPIException e) {
@@ -38,4 +97,38 @@ public class RepositoryController {
 		return;
 	}
 
+	/**
+	 * リポジトリのURLを「/」で区切る
+	 * 
+	 * @return リポジトリのURLのパース結果
+	 */
+	public String[] makeUrlParts() {
+		String[] urlParts = getRepositoryUrl().split("/");
+
+		return urlParts;
+	}
+
+	// public void setLocalPath(String localPath) {
+	// this.localPath = localPath;
+
+	// return;
+	// }
+
+	// public void setOwner(String owner) {
+	// this.owner = owner;
+
+	// return;
+	// }
+
+	// public void setRepositoryName(String repositoryName) {
+	// this.repositoryName = repositoryName;
+
+	// return;
+	// }
+
+	// public void setRepositoryUrl(String repositoryUrl) {
+	// this.repositoryUrl = repositoryUrl;
+
+	// return;
+	// }
 }

--- a/app/src/main/resource/repositories.txt
+++ b/app/src/main/resource/repositories.txt
@@ -1,0 +1,3 @@
+https://github.com/tamadalab/MarryLab.git
+https://github.com/tamadalab/nikusa.git
+https://github.com/spring-projects/spring-boot.git


### PR DESCRIPTION
URLの入力をベタ張りにしていたので、repositories.txtにURLを羅列してシーケンシャルに読み込むようにした。また、ビルドの実行時間を取得できるようにした。